### PR TITLE
EOB Validation fix

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
@@ -12,6 +12,7 @@ import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.ProfileConstants;
 import gov.cms.bfd.server.war.commons.carin.C4BBAdjudication;
 import gov.cms.bfd.server.war.commons.carin.C4BBClaimProfessionalAndNonClinicianCareTeamRole;
+import gov.cms.bfd.server.war.commons.carin.C4BBOrganizationIdentifierType;
 import gov.cms.bfd.server.war.commons.carin.C4BBPractitionerIdentifierType;
 import gov.cms.bfd.sharedutils.exceptions.BadCodeMonkeyException;
 import java.math.BigDecimal;
@@ -225,6 +226,10 @@ public class CarrierClaimTransformerV2 {
           C4BBPractitionerIdentifierType.NPI,
           C4BBClaimProfessionalAndNonClinicianCareTeamRole.PRIMARY,
           line.getOrganizationNpi());
+
+      // ORG_NPI_NUM => ExplanationOfBenefit.provider
+      TransformerUtilsV2.addProviderSlice(
+          eob, C4BBOrganizationIdentifierType.NPI, line.getOrganizationNpi(), Optional.empty());
 
       // CARR_LINE_RDCD_PMT_PHYS_ASTN_C => ExplanationOfBenefit.item.adjudication
       TransformerUtilsV2.addAdjudication(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
@@ -190,6 +190,10 @@ final class DMEClaimTransformerV2 {
               C4BBClaimProfessionalAndNonClinicianCareTeamRole.PERFORMING,
               line.getProviderNPI());
 
+      // PRVDR_NPI => ExplanationOfBenefit.provider
+      TransformerUtilsV2.addProvider(
+          eob, C4BBPractitionerIdentifierType.NPI, line.getProviderNPI());
+
       // Update the responsible flag
       performing.ifPresent(
           p -> {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/PartDEventTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/PartDEventTransformerV2.java
@@ -276,6 +276,10 @@ final class PartDEventTransformerV2 {
         C4BBClaimPharmacyTeamRole.PRESCRIBING,
         Optional.ofNullable(claimGroup.getPrescriberId()));
 
+    // PRSCRBR_ID => ExplanationOfBenefit.provider
+    TransformerUtilsV2.addProvider(
+        eob, C4BBPractitionerIdentifierType.NPI, Optional.ofNullable(claimGroup.getPrescriberId()));
+
     // This can't use TransformerUtilsV2.addNationalDrugCode because it maps differently
     // PROD_SRVC_ID => ExplanationOfBenefit.item.productOrService
     rxItem.setProductOrService(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -74,6 +74,7 @@ import org.hl7.fhir.r4.model.ExplanationOfBenefit.BenefitBalanceComponent;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit.BenefitComponent;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit.CareTeamComponent;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit.ExplanationOfBenefitStatus;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.InsuranceComponent;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit.ItemComponent;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit.ProcedureComponent;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit.RemittanceOutcome;
@@ -1812,7 +1813,10 @@ public final class TransformerUtilsV2 {
         .setType(createC4BBClaimCodeableConcept());
 
     // BENE_ID + Coverage Type => ExplanationOfBenefit.insurance.coverage (ref)
-    eob.addInsurance().setCoverage(referenceCoverage(beneficiaryId, coverageType));
+    // ExplanationOfBenefit.insurance.focal must be provided
+    InsuranceComponent insurance = eob.addInsurance();
+    insurance.setCoverage(referenceCoverage(beneficiaryId, coverageType));
+    insurance.setFocal(true);
 
     // BENE_ID => ExplanationOfBenefit.patient (reference)
     eob.setPatient(referencePatient(beneficiaryId));
@@ -2834,6 +2838,25 @@ public final class TransformerUtilsV2 {
       C4BBClaimProfessionalAndNonClinicianCareTeamRole role,
       Optional<String> id) {
     return addCareTeamMember(eob, null, type, role, id);
+  }
+
+  /**
+   * Optionally sets the provider in {@link ExplanationOfBenefit}
+   *
+   * @param eob the {@link ExplanationOfBenefit} that the {@link #provider} should be added to
+   * @param type Coding System to use, either NPI or UPIN
+   * @param practitionerIdValue the {@link Identifier#getValue()} of the practitioner to reference
+   */
+  static void addProvider(
+      ExplanationOfBenefit eob,
+      C4BBPractitionerIdentifierType type,
+      Optional<String> practitionerIdValue) {
+
+    // ExplanationOfBenefit.provider must be set, so add it if necessary
+    if (!eob.hasProvider()) {
+      practitionerIdValue.ifPresent(
+          value -> eob.setProvider(createPractitionerIdentifierReference(type, value)));
+    }
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
@@ -363,6 +363,13 @@ public class CarrierClaimTransformerV2Test {
     Assert.assertNotNull(eob.getInsurance());
     Assert.assertEquals(
         "Coverage/part-b-567834", eob.getInsurance().get(0).getCoverage().getReference());
+    Assert.assertTrue(eob.getInsurance().get(0).hasFocal());
+  }
+
+  /** ExplanationOfBenefit.provider */
+  @Test
+  public void shouldHaveProvider() {
+    Assert.assertTrue(eob.hasProvider());
   }
 
   @Test

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2Test.java
@@ -293,11 +293,17 @@ public final class DMEClaimTransformerV2Test {
 
     InsuranceComponent insurance = eob.getInsuranceFirstRep();
 
-    InsuranceComponent compare =
-        new InsuranceComponent()
-            .setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+    InsuranceComponent compare = new InsuranceComponent();
+    compare.setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+    compare.setFocal(true);
 
     Assert.assertTrue(compare.equalsDeep(insurance));
+  }
+
+  /** ExplanationOfBenefit.provider */
+  @Test
+  public void shouldHaveProvider() {
+    Assert.assertTrue(eob.hasProvider());
   }
 
   /** Line Items */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HHAClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HHAClaimTransformerV2Test.java
@@ -529,11 +529,17 @@ public class HHAClaimTransformerV2Test {
 
     InsuranceComponent insurance = eob.getInsuranceFirstRep();
 
-    InsuranceComponent compare =
-        new InsuranceComponent()
-            .setCoverage(new Reference().setReference("Coverage/part-b-567834"));
+    InsuranceComponent compare = new InsuranceComponent();
+    compare.setCoverage(new Reference().setReference("Coverage/part-b-567834"));
+    compare.setFocal(true);
 
     Assert.assertTrue(compare.equalsDeep(insurance));
+  }
+
+  /** ExplanationOfBenefit.provider */
+  @Test
+  public void shouldHaveProvider() {
+    Assert.assertTrue(eob.hasProvider());
   }
 
   /** Line Items */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HospiceClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HospiceClaimTransformerV2Test.java
@@ -486,11 +486,18 @@ public final class HospiceClaimTransformerV2Test {
     Assert.assertEquals(1, eob.getInsurance().size());
 
     InsuranceComponent insurance = eob.getInsuranceFirstRep();
-    InsuranceComponent compare =
-        new InsuranceComponent()
-            .setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+
+    InsuranceComponent compare = new InsuranceComponent();
+    compare.setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+    compare.setFocal(true);
 
     Assert.assertTrue(compare.equalsDeep(insurance));
+  }
+
+  /** ExplanationOfBenefit.provider */
+  @Test
+  public void shouldHaveProvider() {
+    Assert.assertTrue(eob.hasProvider());
   }
 
   @Test

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2Test.java
@@ -892,11 +892,17 @@ public final class InpatientClaimTransformerV2Test {
 
     InsuranceComponent insurance = eob.getInsuranceFirstRep();
 
-    InsuranceComponent compare =
-        new InsuranceComponent()
-            .setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+    InsuranceComponent compare = new InsuranceComponent();
+    compare.setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+    compare.setFocal(true);
 
     Assert.assertTrue(compare.equalsDeep(insurance));
+  }
+
+  /** ExplanationOfBenefit.provider */
+  @Test
+  public void shouldHaveProvider() {
+    Assert.assertTrue(eob.hasProvider());
   }
 
   /** Top level Type */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
@@ -475,11 +475,17 @@ public final class OutpatientClaimTransformerV2Test {
 
     InsuranceComponent insurance = eob.getInsuranceFirstRep();
 
-    InsuranceComponent compare =
-        new InsuranceComponent()
-            .setCoverage(new Reference().setReference("Coverage/part-b-567834"));
+    InsuranceComponent compare = new InsuranceComponent();
+    compare.setCoverage(new Reference().setReference("Coverage/part-b-567834"));
+    compare.setFocal(true);
 
     Assert.assertTrue(compare.equalsDeep(insurance));
+  }
+
+  /** ExplanationOfBenefit.provider */
+  @Test
+  public void shouldHaveProvider() {
+    Assert.assertTrue(eob.hasProvider());
   }
 
   /** Line Items */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/SNFClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/SNFClaimTransformerV2Test.java
@@ -772,11 +772,17 @@ public class SNFClaimTransformerV2Test {
 
     InsuranceComponent insurance = eob.getInsuranceFirstRep();
 
-    InsuranceComponent compare =
-        new InsuranceComponent()
-            .setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+    InsuranceComponent compare = new InsuranceComponent();
+    compare.setCoverage(new Reference().setReference("Coverage/part-a-567834"));
+    compare.setFocal(true);
 
     Assert.assertTrue(compare.equalsDeep(insurance));
+  }
+
+  /** ExplanationOfBenefit.provider */
+  @Test
+  public void shouldHaveProvider() {
+    Assert.assertTrue(eob.hasProvider());
   }
 
   /** Line Items */

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobByPatientIdAll.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobByPatientIdAll.json
@@ -915,6 +915,17 @@
           "value" : "CMS"
         }
       },
+        "identifier": {
+          "type": {
+            "coding": [ {
+              "system": "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+              "code": "npi",
+              "display": "National Provider Identifier"
+            } ]
+          },
+          "value": "1244444444"
+        }
+      },
       "referral" : {
         "identifier" : {
           "type" : {
@@ -1068,6 +1079,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }
@@ -1883,6 +1895,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-b-567834"
         }
@@ -2709,6 +2722,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }
@@ -3634,6 +3648,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }
@@ -3984,6 +3999,19 @@
           "value" : "CMS"
         }
       },
+      "provider" : {
+        "identifier" : {
+          "type" : {
+            "coding" : [ {
+              "system" : "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+              "code" : "npi",
+              "display" : "National Provider Identifier"
+            } ]
+          },
+          "value" : "1750384806"
+        },
+        "display" : "DR. ROBERT BISBEE MD"
+      },
       "facility" : {
         "extension" : [ {
           "url" : "https://bluebutton.cms.gov/resources/variables/phrmcy_srvc_type_cd",
@@ -4302,6 +4330,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "extension" : [ {
             "url" : "https://bluebutton.cms.gov/resources/variables/plan_cntrct_rec_id",
@@ -4492,6 +4521,23 @@
         "profile" : [ "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit-Professional-NonClinician" ]
       },
       "contained" : [ {
+        "resourceType" : "Organization",
+        "id" : "provider-org",
+        "meta" : {
+          "profile" : [ "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Organization" ]
+        },
+        "identifier" : [ {
+          "type" : {
+            "coding" : [ {
+              "system" : "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+              "code" : "npi"
+            } ]
+          },
+          "system" : "http://hl7.org/fhir/sid/us-npi",
+          "value" : "1497758544"
+        } ],
+        "active" : true
+      }, {
         "resourceType" : "Observation",
         "id" : "line-observation-6",
         "status" : "unknown",
@@ -4602,6 +4648,9 @@
         "identifier" : {
           "value" : "CMS"
         }
+      },
+      "provider" : {
+        "reference" : "#provider-org"
       },
       "referral" : {
         "identifier" : {
@@ -4833,6 +4882,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-b-567834"
         }
@@ -5540,6 +5590,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobByPatientIdAll.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobByPatientIdAll.json
@@ -395,6 +395,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-b-567834"
         }
@@ -915,6 +916,7 @@
           "value" : "CMS"
         }
       },
+      "provider" : {
         "identifier": {
           "type": {
             "coding": [ {

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobByPatientIdPaged.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobByPatientIdPaged.json
@@ -401,6 +401,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-b-567834"
         }
@@ -921,6 +922,18 @@
           "value" : "CMS"
         }
       },
+      "provider" : {
+        "identifier": {
+          "type": {
+            "coding": [ {
+              "system": "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+              "code": "npi",
+              "display": "National Provider Identifier"
+            } ]
+          },
+          "value": "1244444444"
+        }
+      },
       "referral" : {
         "identifier" : {
           "type" : {
@@ -1074,6 +1087,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }
@@ -1889,6 +1903,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-b-567834"
         }
@@ -2715,6 +2730,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }
@@ -3640,6 +3656,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }
@@ -3990,6 +4007,19 @@
           "value" : "CMS"
         }
       },
+      "provider" : {
+        "identifier" : {
+          "type" : {
+            "coding" : [ {
+              "system" : "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+              "code" : "npi",
+              "display" : "National Provider Identifier"
+            } ]
+          },
+          "value" : "1750384806"
+        },
+        "display" : "DR. ROBERT BISBEE MD"
+      },
       "facility" : {
         "extension" : [ {
           "url" : "https://bluebutton.cms.gov/resources/variables/phrmcy_srvc_type_cd",
@@ -4308,6 +4338,7 @@
         }
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "extension" : [ {
             "url" : "https://bluebutton.cms.gov/resources/variables/plan_cntrct_rec_id",
@@ -4498,6 +4529,23 @@
         "profile" : [ "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit-Professional-NonClinician" ]
       },
       "contained" : [ {
+        "resourceType" : "Organization",
+        "id" : "provider-org",
+        "meta" : {
+          "profile" : [ "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Organization" ]
+        },
+        "identifier" : [ {
+          "type" : {
+            "coding" : [ {
+              "system" : "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+              "code" : "npi"
+            } ]
+          },
+          "system" : "http://hl7.org/fhir/sid/us-npi",
+          "value" : "1497758544"
+        } ],
+        "active" : true
+      }, {
         "resourceType" : "Observation",
         "id" : "line-observation-6",
         "status" : "unknown",
@@ -4608,6 +4656,9 @@
         "identifier" : {
           "value" : "CMS"
         }
+      },
+      "provider" : {
+        "reference" : "#provider-org"
       },
       "referral" : {
         "identifier" : {
@@ -4839,6 +4890,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-b-567834"
         }
@@ -5546,6 +5598,7 @@
         } ]
       } ],
       "insurance" : [ {
+        "focal" : true,
         "coverage" : {
           "reference" : "Coverage/part-a-567834"
         }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadCarrier.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadCarrier.json
@@ -6,6 +6,24 @@
     "profile" : [ "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit-Professional-NonClinician" ]
   },
   "contained" : [ {
+      "resourceType":"Organization",
+      "id":"provider-org",
+      "meta":{
+        "profile":[
+          "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Organization"
+        ] },
+      "identifier":[ {
+        "type":{
+          "coding":[ {
+            "system":"http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+            "code":"npi"
+          } ]
+        },
+        "system":"http://hl7.org/fhir/sid/us-npi",
+        "value":"1497758544"
+      } ],
+      "active":true
+    },{
     "resourceType" : "Observation",
     "id" : "line-observation-6",
     "status" : "unknown",
@@ -116,6 +134,9 @@
     "identifier" : {
       "value" : "CMS"
     }
+  },
+  "provider":{
+    "reference":"#provider-org"
   },
   "referral" : {
     "identifier" : {
@@ -347,6 +368,7 @@
     } ]
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-b-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadCarrierWithTaxNumbers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadCarrierWithTaxNumbers.json
@@ -6,6 +6,24 @@
     "profile" : [ "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit-Professional-NonClinician" ]
   },
   "contained" : [ {
+      "resourceType":"Organization",
+      "id":"provider-org",
+      "meta":{
+        "profile":[
+          "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-Organization"
+        ] },
+      "identifier":[ {
+        "type":{
+          "coding":[ {
+            "system":"http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+            "code":"npi"
+          } ]
+        },
+        "system":"http://hl7.org/fhir/sid/us-npi",
+        "value":"1497758544"
+      } ],
+      "active":true
+    },{
     "resourceType" : "Observation",
     "id" : "line-observation-6",
     "status" : "unknown",
@@ -116,6 +134,9 @@
     "identifier" : {
       "value" : "CMS"
     }
+  },
+  "provider":{
+    "reference":"#provider-org"
   },
   "referral" : {
     "identifier" : {
@@ -347,6 +368,7 @@
     } ]
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-b-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadDme.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadDme.json
@@ -117,6 +117,18 @@
       "value" : "CMS"
     }
   },
+  "provider" : {
+    "identifier": {
+      "type": {
+        "coding": [ {
+          "system": "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+          "code": "npi",
+          "display": "National Provider Identifier"
+        } ]
+      },
+      "value": "1244444444"
+    }
+  },
   "referral" : {
     "identifier" : {
       "type" : {
@@ -270,6 +282,7 @@
     } ]
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-a-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadDmeWithTaxNumbers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadDmeWithTaxNumbers.json
@@ -117,6 +117,18 @@
       "value" : "CMS"
     }
   },
+  "provider" : {
+    "identifier": {
+      "type": {
+        "coding": [ {
+          "system": "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+          "code": "npi",
+          "display": "National Provider Identifier"
+        } ]
+      },
+      "value": "1244444444"
+    }
+  },
   "referral" : {
     "identifier" : {
       "type" : {
@@ -270,6 +282,7 @@
     } ]
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-a-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadHha.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadHha.json
@@ -375,6 +375,7 @@
     } ]
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-b-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadHospice.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadHospice.json
@@ -341,6 +341,7 @@
     } ]
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-a-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadInpatient.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadInpatient.json
@@ -652,6 +652,7 @@
     }
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-a-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadOutpatient.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadOutpatient.json
@@ -382,6 +382,7 @@
     }
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-b-567834"
     }

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadPde.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadPde.json
@@ -61,6 +61,19 @@
       "value" : "CMS"
     }
   },
+  "provider" : {
+    "identifier" : {
+      "type" : {
+        "coding" : [ {
+          "system" : "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBIdentifierType",
+          "code" : "npi",
+          "display" : "National Provider Identifier"
+        } ]
+      },
+      "value" : "1750384806"
+    },
+    "display" : "DR. ROBERT BISBEE MD"
+  },
   "facility" : {
     "extension" : [ {
       "url" : "https://bluebutton.cms.gov/resources/variables/phrmcy_srvc_type_cd",
@@ -379,6 +392,7 @@
     }
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "extension" : [ {
         "url" : "https://bluebutton.cms.gov/resources/variables/plan_cntrct_rec_id",

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadSnf.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/v2/eobReadSnf.json
@@ -560,6 +560,7 @@
     }
   } ],
   "insurance" : [ {
+    "focal" : true,
     "coverage" : {
       "reference" : "Coverage/part-a-567834"
     }


### PR DESCRIPTION
This PR fixes: https://github.com/CMSgov/beneficiary-fhir-data/issues/804

The Carin Blue Button Implementation Guide requires ExplanationOfBenefit.provider and ExplanationOfBenefit.insurance.focal to be set.  This PR sets those fields in the FHIR R4 synthetic beneficiary fhir data.

Without these fields, FHIR R4 validation done by the LinuxForHealth connect API fails.
    
Implementation notes:
- ExplanationOfBenefit.insurance.focal = true was added to every EOB type, since the insurance instances are created on the fly.  All tests were updated to also check that focal is either set or the expected value, depending on the test.

- ExplanationOfBenefit.provider already exists for some claim types like SNF, which uses TransformerUtilsV2.addProviderSlice().  This approach was used in this PR for most claim types except PDE and DME.  addProviderSlice() adds the provider org NPI to ExplanationOfBenefit.contained and adds an ExplanationOfBenefit.provider instance that refers to ExplanationOfBenefit.contained.

- For PDE and DME claim types, an addProvider() method was added to TransformerUtilsV2 to add the provider field directly, without reference, based on the practitioner or provider NPI.

- All tests were updated and the expected responses were updated by adding the new fields to the existing responses.